### PR TITLE
Unify build log names and use --no-cache everythere

### DIFF
--- a/images/build-fullnode-btcd.sh
+++ b/images/build-fullnode-btcd.sh
@@ -14,11 +14,11 @@ BINDIR=$BUILDDIR/bin
 echo "Build Dir:   $BUILDDIR"
 
 cd $BUILDDIR
-docker build --no-cache -t fullnode-btcd-build -f Dockerfile-build . | tee build.log
-docker run --rm -v $BINDIR:/build fullnode-btcd-build | tee build-run.log
+docker build --no-cache -t fullnode-btcd-build -f Dockerfile-build . | tee buildimage.log
+docker run --rm -v $BINDIR:/build fullnode-btcd-build | tee buildimage-run.log
 echo ... built btcd binaries:
 ls -la $BINDIR
 echo ... creating fullnode-btcd image
 VERSION=`cat $BINDIR/VERSION`
-docker build -t fullnode-btcd --label version="$VERSION" . | tee fullnode-build.log
+docker build --no-cache -t fullnode-btcd --label version="$VERSION" . | tee buildfinal.log
 cd -

--- a/images/build-xchange-crawler.sh
+++ b/images/build-xchange-crawler.sh
@@ -12,10 +12,10 @@ echo [build] ---- building $IMAGE image ----
 
 cd $DIR/$IMAGE
 
-docker build --no-cache -t ${IMAGE}-build -f Dockerfile-build . | tee build.log
-docker run --rm -v "$PWD"/bin:/build "${IMAGE}-build" | tee build-run.log
+docker build --no-cache -t ${IMAGE}-build -f Dockerfile-build . | tee buildimage.log
+docker run --rm -v "$PWD"/bin:/build "${IMAGE}-build" | tee buildimage-run.log
 ls -la "$PWD"/bin
 echo ... creating $IMAGE
 VERSION=`cat $PWD/bin/VERSION`
-docker build -t $IMAGE --label version="$VERSION" . | tee build-$IMAGE.log
+docker build --no-cache -t $IMAGE --label version="$VERSION" . | tee buildfinal.log
 cd -


### PR DESCRIPTION
    buildimage.log      - image used to build binaries
    buildimage-run.log  - run of build image to get binaries
    buildfinal.log      - packing binaries to final image