### PR TITLE
Start stable containers (btcd) automatically

### DIFF
--- a/images/run-fullnode-btcd.sh
+++ b/images/run-fullnode-btcd.sh
@@ -1,8 +1,9 @@
 IMAGE=fullnode-btcd
 NAME=btcd
 VERSION=`docker inspect --format='{{.Config.Labels.version}}' $IMAGE`
-echo Running $NAME $VERSION from $IMAGE
-docker run -d -u $(id -u cyber) -p 8333:8333 --name $NAME -v /home/cyber/cyberdata/$NAME:/cyberdata $IMAGE
+
+echo ... starting $NAME $VERSION from $IMAGE
+docker run -d --restart always -u $(id -u cyber) -p 8333:8333 --name $NAME -v /home/cyber/cyberdata/$NAME:/cyberdata $IMAGE
 #    -d                  - run as daemon 
 #    -u $(id -u cyber)   - run container under user `cyber`, param needs uid
 #    -p 8333:8333        - host:container - expose port 8333 as 8333 from host


### PR DESCRIPTION
"always" policy means container will be automatically
restarted unless stopped manually or if it fails to start.

https://docs.docker.com/engine/admin/start-containers-automatically/#restart-policy-details

This will be managed by Kubernetes.