### PR TITLE
`btcd` dockerization updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   # markets
   - ./images/build-markets.sh
 
-before_deploy:
+after_script:
   - ./images/run-fullnode-btcd.sh --version
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ script:
   # markets
   - ./images/build-markets.sh
 
+before_deploy:
+  - ./images/run-fullnode-btcd.sh --version
+
 cache:
   # parity
   - cargo

--- a/images/README.md
+++ b/images/README.md
@@ -20,9 +20,6 @@ Check image command and parameters:
 
     docker inspect --format='{{.Config.Entrypoint}}' btcd
 
-Explore *container* filesystem:
-
-    docker export btcd | tar -tv
 
 ### Intro
 
@@ -148,3 +145,33 @@ or run `docker` with explicit user command:
 `-u` or `--user` options doesn't accept user name and
 requires numeric UID passed as parameter, for details, see
 https://github.com/moby/moby/issues/22323#issuecomment-215449380
+
+
+### Troubleshooting
+
+We pack binaries in read-only docker images. They become
+read-only when we run them under user `cyber` who is
+different from `root` and don't have write access to
+anything except mounted volumes.
+
+For example, if `docker logs` shows:
+
+    loadConfig: Failed to create home directory: mkdir /.btcd: permission denied
+
+That means that `btcd` can not create `/.btcd` because
+there is no rights for `cyber` user to create dir in
+container root, and all processes run in root dir by
+default. Make sure that application writes all its files
+in `/cyberdata` volume.
+
+To discover commands that shell scrips run, launch them
+with bash `-x`:
+
+    bash -x run-fullnode-btcd.sh
+
+It also helps to run container as root (remove -u UID param
+from `docker run`) and explore its filesystem afterwards
+with:
+
+    docker export btcd | tar -tv
+

--- a/images/README.md
+++ b/images/README.md
@@ -1,42 +1,53 @@
-*Automation for `cybernode` images*
+*Build scripts for `cybernode` images*
 
 ### TL;DR
 
-Run `./build-*.sh` scripts. **Build images** are not
-pushed. Binaries are extracted to `bin/` subdir of image
-sources.
+Use `./build-*.sh` scripts to build and pack binaries
+into Docker images. Use `./run-*.sh` scripts to execute
+images.
+
+For debugging, binaries are extracted to `bin/` subdir of
+image sources. Images that end in `-build` are used for
+building process itself and can be removed.
 
 ### Common operations
 
-Check version of dockerized software (`btcd` for example):
+Check version of image software (`btcd` for example):
 
     docker inspect --format='{{.Config.Labels.version}}' btcd
+
+Check image command and parameters:
+
+    docker inspect --format='{{.Config.Entrypoint}}' btcd
+
+Explore *container* filesystem:
+
+    docker export btcd | tar -tv
 
 ### Intro
 
 `cybernode` is a cluster of services. Every service runs in
-container to simplify administration, deployment and
-automatic management (also known as `orchestration`).
+own container to simplify "administration, deployment and
+automatic management" (also known as `orchestration`).
 
 Docker is the current choice for running production
-containers. On the other hand image build scripts are kept
+containers. But scripts for building software are kept
 decoupled from Docker for easy migration to alternative
 container providers.
 
-Independent build scripts are named as `01build.sh`, Docker
+Software build scripts are named as `01build.sh`, Docker
 specific files are `Dockerfile` and `Dockerfile-build`.
 Main `build.sh` file currently contains docker commands.
 
 
 ### Building images with Docker
 
-Build process - dependendency download, compilation and
-packaging leaves a lot of garbage on the build system.
-Build tools, sources and dependencies are usually not
-needed for operations. That's why we use separate
-**build images** to build and package things and separate
-**run images** to deploy software. **run images** are what
-is uploaded to public repositories.
+Software for image is built from sources. Build process
+takes place inside special **build image** to isolate
+build artifacts, tools, sources and dependencies from host
+system and target image. The target image with compiled
+binary is called **run image** and it is the one uploaded
+to container repositories.
 
 ##### Build images
 

--- a/images/cleanup.sh
+++ b/images/cleanup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# remove dangling images (unused <none>:<none>)
+echo "...remove dangling images (unused <none>:<none>)"
 docker rmi $(docker images --quiet --filter "dangling=true")

--- a/images/fullnode/btcd/01build.sh
+++ b/images/fullnode/btcd/01build.sh
@@ -3,6 +3,9 @@
 # fail on error
 set -e
 
+# absolute path to script's directory
+DIR=$(dirname $(readlink -f "$0"))
+
 BTCDHASH=master
 
 echo --- detecting defaults ---
@@ -16,6 +19,9 @@ echo --- clone btcd sources ---
 git clone https://github.com/btcsuite/btcd $GOPATH/src/github.com/btcsuite/btcd
 cd $GOPATH/src/github.com/btcsuite/btcd
 git checkout $BTCDHASH
+
+echo --- applying patches ---
+git am $DIR/02notls.patch
 
 echo --- fetch dependencies into vendor/ ---
 $GOPATH/bin/glide install

--- a/images/fullnode/btcd/01build.sh
+++ b/images/fullnode/btcd/01build.sh
@@ -3,6 +3,8 @@
 # fail on error
 set -e
 
+BTCDHASH=master
+
 echo --- detecting defaults ---
 go version && go env GOROOT GOPATH
 
@@ -12,6 +14,7 @@ go get -u github.com/Masterminds/glide
 echo --- clone btcd sources ---
 git clone https://github.com/btcsuite/btcd $GOPATH/src/github.com/btcsuite/btcd
 cd $GOPATH/src/github.com/btcsuite/btcd
+git checkout $BTCDHASH
 
 echo --- fetch dependencies into vendor/ ---
 glide install

--- a/images/fullnode/btcd/01build.sh
+++ b/images/fullnode/btcd/01build.sh
@@ -7,6 +7,7 @@ BTCDHASH=master
 
 echo --- detecting defaults ---
 go version && go env GOROOT GOPATH
+GOPATH=`go env GOPATH`
 
 echo --- get dependency manager ---
 go get -u github.com/Masterminds/glide
@@ -17,7 +18,7 @@ cd $GOPATH/src/github.com/btcsuite/btcd
 git checkout $BTCDHASH
 
 echo --- fetch dependencies into vendor/ ---
-glide install
+$GOPATH/bin/glide install
 ls -la $GOPATH/bin
 
 echo --- build all tools found in cmd/ to $GOPATH/bin ---

--- a/images/fullnode/btcd/01build.sh
+++ b/images/fullnode/btcd/01build.sh
@@ -19,9 +19,14 @@ echo --- clone btcd sources ---
 git clone https://github.com/btcsuite/btcd $GOPATH/src/github.com/btcsuite/btcd
 cd $GOPATH/src/github.com/btcsuite/btcd
 git checkout $BTCDHASH
+# record revision
+touch $GOPATH/bin/VERSION
+echo "btcd-revision: `git rev-parse HEAD`" >> $GOPATH/bin/VERSION
 
 echo --- applying patches ---
 git -c user.name='cyber' -c user.email='cyber@build' am $DIR/02notls.patch
+echo "patch-revision: `git rev-parse HEAD`" >> $GOPATH/bin/VERSION
+
 
 echo --- fetch dependencies into vendor/ ---
 $GOPATH/bin/glide install
@@ -30,6 +35,4 @@ ls -la $GOPATH/bin
 echo --- build all tools found in cmd/ to $GOPATH/bin ---
 # static compile to work on any Linux
 CGO_ENABLED=0 go install . ./cmd/...
-# record version
-git rev-parse HEAD > $GOPATH/bin/VERSION
 ls -la $GOPATH/bin

--- a/images/fullnode/btcd/01build.sh
+++ b/images/fullnode/btcd/01build.sh
@@ -21,7 +21,7 @@ cd $GOPATH/src/github.com/btcsuite/btcd
 git checkout $BTCDHASH
 
 echo --- applying patches ---
-git am $DIR/02notls.patch
+git -c user.name='cyber' -c user.email='cyber@build' am $DIR/02notls.patch
 
 echo --- fetch dependencies into vendor/ ---
 $GOPATH/bin/glide install

--- a/images/fullnode/btcd/02notls.patch
+++ b/images/fullnode/btcd/02notls.patch
@@ -1,4 +1,4 @@
-From 401ae469f550cd4536b89864703e2825aff5e598 Mon Sep 17 00:00:00 2001
+From 31ca0861386d15f648a34af7bfd5be1359b6537d Mon Sep 17 00:00:00 2001
 From: Anatoli Babenia <anatoli@rainforce.org>
 Date: Thu, 17 Aug 2017 01:44:22 +0300
 Subject: [PATCH] Allow --notls when listening on all interfaces
@@ -7,14 +7,14 @@ This is useful when wrapping `btcd` into docker container,
 which requires internal process to listen on external ports
 to forward them to 127.0.0.1:8334 on host.
 ---
- config.go | 19 ++-----------------
- 1 file changed, 2 insertions(+), 17 deletions(-)
+ config.go | 21 +++------------------
+ 1 file changed, 3 insertions(+), 18 deletions(-)
 
 diff --git a/config.go b/config.go
-index 1266ce48b..d771931f2 100644
+index 1266ce4..ca1202b 100644
 --- a/config.go
 +++ b/config.go
-@@ -862,14 +862,8 @@ func loadConfig() (*config, []string, error) {
+@@ -862,16 +862,10 @@ func loadConfig() (*config, []string, error) {
  	cfg.RPCListeners = normalizeAddresses(cfg.RPCListeners,
  		activeNetParams.rpcPort)
  
@@ -29,8 +29,11 @@ index 1266ce48b..d771931f2 100644
 +	// Check RPC addresses and allow TLS to be disabled for all requests.
 +	if !cfg.DisableRPC {
  		for _, addr := range cfg.RPCListeners {
- 			host, _, err := net.SplitHostPort(addr)
+-			host, _, err := net.SplitHostPort(addr)
++			_, _, err := net.SplitHostPort(addr)
  			if err != nil {
+ 				str := "%s: RPC listen interface '%s' is " +
+ 					"invalid: %v"
 @@ -880,15 +874,6 @@ func loadConfig() (*config, []string, error) {
  				fmt.Fprintln(os.Stderr, usageMessage)
  				return nil, nil, err
@@ -47,4 +50,6 @@ index 1266ce48b..d771931f2 100644
  		}
  	}
  
+-- 
+2.13.5
 

--- a/images/fullnode/btcd/02notls.patch
+++ b/images/fullnode/btcd/02notls.patch
@@ -1,0 +1,50 @@
+From 401ae469f550cd4536b89864703e2825aff5e598 Mon Sep 17 00:00:00 2001
+From: Anatoli Babenia <anatoli@rainforce.org>
+Date: Thu, 17 Aug 2017 01:44:22 +0300
+Subject: [PATCH] Allow --notls when listening on all interfaces
+
+This is useful when wrapping `btcd` into docker container,
+which requires internal process to listen on external ports
+to forward them to 127.0.0.1:8334 on host.
+---
+ config.go | 19 ++-----------------
+ 1 file changed, 2 insertions(+), 17 deletions(-)
+
+diff --git a/config.go b/config.go
+index 1266ce48b..d771931f2 100644
+--- a/config.go
++++ b/config.go
+@@ -862,14 +862,8 @@ func loadConfig() (*config, []string, error) {
+ 	cfg.RPCListeners = normalizeAddresses(cfg.RPCListeners,
+ 		activeNetParams.rpcPort)
+ 
+-	// Only allow TLS to be disabled if the RPC is bound to localhost
+-	// addresses.
+-	if !cfg.DisableRPC && cfg.DisableTLS {
+-		allowedTLSListeners := map[string]struct{}{
+-			"localhost": {},
+-			"127.0.0.1": {},
+-			"::1":       {},
+-		}
++	// Check RPC addresses and allow TLS to be disabled for all requests.
++	if !cfg.DisableRPC {
+ 		for _, addr := range cfg.RPCListeners {
+ 			host, _, err := net.SplitHostPort(addr)
+ 			if err != nil {
+@@ -880,15 +874,6 @@ func loadConfig() (*config, []string, error) {
+ 				fmt.Fprintln(os.Stderr, usageMessage)
+ 				return nil, nil, err
+ 			}
+-			if _, ok := allowedTLSListeners[host]; !ok {
+-				str := "%s: the --notls option may not be used " +
+-					"when binding RPC to non localhost " +
+-					"addresses: %s"
+-				err := fmt.Errorf(str, funcName, addr)
+-				fmt.Fprintln(os.Stderr, err)
+-				fmt.Fprintln(os.Stderr, usageMessage)
+-				return nil, nil, err
+-			}
+ 		}
+ 	}
+ 
+

--- a/images/fullnode/btcd/Dockerfile
+++ b/images/fullnode/btcd/Dockerfile
@@ -9,7 +9,8 @@ EXPOSE 8333
 # JSON-RPC + WebSockets
 EXPOSE 8334
 
-ENTRYPOINT ["/cyberapp/btcd", "--datadir=/cyberdata"]
-# disable logging to disk by default
-# access with `docker logs` instead
-CMD ["--logdir="]
+ENTRYPOINT ["/cyberapp/btcd", "--datadir=/cyberdata", "--logdir=/cyberdata"]
+# [ ] disable logging to disk by default
+#     and access with `docker logs` instead
+#     https://github.com/btcsuite/btcd/issues/994
+CMD []

--- a/images/fullnode/btcd/Dockerfile
+++ b/images/fullnode/btcd/Dockerfile
@@ -9,4 +9,7 @@ EXPOSE 8333
 # JSON-RPC + WebSockets
 EXPOSE 8334
 
-CMD ["/cyberapp/btcd", "--datadir=/cyberdata"]
+ENTRYPOINT ["/cyberapp/btcd"]
+# disable logging to disk by default
+# access with `docker logs` instead
+CMD ["--datadir=/cyberdata --logir="]

--- a/images/fullnode/btcd/Dockerfile
+++ b/images/fullnode/btcd/Dockerfile
@@ -3,6 +3,10 @@ FROM scratch
 ADD bin/* /cyberapp/
 VOLUME /cyberdata
 
+# `btcd` still tries to create its .btcd
+# https://github.com/btcsuite/btcd/issues/995
+ENV HOME /cyberdata
+
 # https://github.com/btcsuite/btcd/blob/master/docs/default_ports.md
 # Bitcoin P2P
 EXPOSE 8333

--- a/images/fullnode/btcd/Dockerfile
+++ b/images/fullnode/btcd/Dockerfile
@@ -4,6 +4,9 @@ ADD bin/* /cyberapp/
 VOLUME /cyberdata
 
 # https://github.com/btcsuite/btcd/blob/master/docs/default_ports.md
+# Bitcoin P2P
 EXPOSE 8333
+# JSON-RPC + WebSockets
+EXPOSE 8334
 
 CMD ["/cyberapp/btcd", "--datadir=/cyberdata"]

--- a/images/fullnode/btcd/Dockerfile
+++ b/images/fullnode/btcd/Dockerfile
@@ -9,7 +9,7 @@ EXPOSE 8333
 # JSON-RPC + WebSockets
 EXPOSE 8334
 
-ENTRYPOINT ["/cyberapp/btcd"]
+ENTRYPOINT ["/cyberapp/btcd", "--datadir=/cyberdata"]
 # disable logging to disk by default
 # access with `docker logs` instead
-CMD ["--datadir=/cyberdata --logir="]
+CMD ["--logdir="]

--- a/images/fullnode/btcd/Dockerfile-build
+++ b/images/fullnode/btcd/Dockerfile-build
@@ -7,7 +7,7 @@ FROM golang:1.8
 # GOPATH: /go
 
 # build time commands
-COPY 01build.sh .
+COPY [0-9]* ./
 RUN ./01build.sh
 
 VOLUME /build

--- a/images/fullnode/btcd/README.md
+++ b/images/fullnode/btcd/README.md
@@ -7,7 +7,8 @@
 ### btcd configuration and docs
 
 See `btcd --help` ([online](https://godoc.org/github.com/btcsuite/btcd))
-for command line options and config, and the rest at
+and [sample-btcd.conf](https://github.com/btcsuite/btcd/blob/master/sample-btcd.conf)
+for configuration description and the rest of the docs at
 https://github.com/btcsuite/btcd/tree/master/docs#table-of-contents
 
 ### Building image

--- a/images/fullnode/btcd/README.md
+++ b/images/fullnode/btcd/README.md
@@ -28,7 +28,7 @@ the following layout:
 
 * `/cyberapp/btcd`     - main process
 * `/cyberapp/VERSION`  - revision in btcd repository
-* `/cyberdata`         - volume with blockchain data
+* `/cyberdata`         - volume for btcd/blockchain data
 
 ### btcd config docs
 

--- a/images/fullnode/btcd/README.md
+++ b/images/fullnode/btcd/README.md
@@ -11,17 +11,23 @@ to set certain paths:
     --rpccert=        File containing the certificate file ($HOME/.btcd/rpc.cert)
     --rpckey=         File containing the certificate key ($HOME/.btcd/rpc.key)
 
-We can set $HOME to (which is unset for Docker container)
-to `/cyberdata` and it will make `btcd` store its files in
-$CYBERDATA/.btcd on container host, but instead we modify
-every option to remove `.btcd` prefix and store data using
-the following layout:
+Even when these params are explicitly set to be out of
+`.btcd` the app still tries to create this directory at
+$HOME which is unset for containers, and this attemp makes
+container fail. https://github.com/btcsuite/btcd/issues/995
 
-    $CYBERDATA/btcd.conf
-    $CYBERDATA/rpc.cert
-    $CYBERDATA/rpc.key
+So we explicitly set chain locations:
+
     $CYBERDATA/<netname>           - blockchain data
     $CYBERDATA/<netname>/btcd.log  - chain logs
+
+But for everything else we set HOME environment variable to
+/cyberdata to allow `btcd` create `/cyberdata/.btcd` and be
+happy. This set location for the following files:
+
+    $CYBERDATA/.btcd/btcd.conf
+    $CYBERDATA/.btcd/rpc.cert
+    $CYBERDATA/.btcd/rpc.key
 
 
 ### fullnode-btcd image layout

--- a/images/fullnode/btcd/README.md
+++ b/images/fullnode/btcd/README.md
@@ -1,10 +1,20 @@
+### btcd setup
+
+`btcd` lacks single BTCDHOME setting to root its data
+under a single directory, such as `/cyberdata`. It uses
+$HOME/.btcd location by default and the following options
+to move certain locations:
+
+
+CYBERDATA
+
 ### fullnode-btcd image layout
 
 * `/cyberapp/btcd`     - main process
 * `/cyberapp/VERSION`  - revision in btcd repository
 * `/cyberdata`         - volume with blockchain data
 
-### btcd configuration and docs
+### btcd config docs
 
 See `btcd --help` ([online](https://godoc.org/github.com/btcsuite/btcd))
 and [sample-btcd.conf](https://github.com/btcsuite/btcd/blob/master/sample-btcd.conf)

--- a/images/fullnode/btcd/README.md
+++ b/images/fullnode/btcd/README.md
@@ -3,10 +3,26 @@
 `btcd` lacks single BTCDHOME setting to root its data
 under a single directory, such as `/cyberdata`. It uses
 $HOME/.btcd location by default and the following options
-to move certain locations:
+to set certain paths:
 
+    --configfile=     Path to configuration file ($HOME/.btcd/btcd.conf)
+    --datadir=        Directory to store data ($HOME/.btcd/data)
+    --logdir=         Directory to log output. ($HOME/.btcd/logs)
+    --rpccert=        File containing the certificate file ($HOME/.btcd/rpc.cert)
+    --rpckey=         File containing the certificate key ($HOME/.btcd/rpc.key)
 
-CYBERDATA
+We can set $HOME to (which is unset for Docker container)
+to `/cyberdata` and it will make `btcd` store its files in
+$CYBERDATA/.btcd on container host, but instead we modify
+every option to remove `.btcd` prefix and store data using
+the following layout:
+
+    $CYBERDATA/btcd.conf
+    $CYBERDATA/rpc.cert
+    $CYBERDATA/rpc.key
+    $CYBERDATA/<netname>           - blockchain data
+    $CYBERDATA/<netname>/btcd.log  - chain logs
+
 
 ### fullnode-btcd image layout
 

--- a/images/fullnode/btcd/README.md
+++ b/images/fullnode/btcd/README.md
@@ -37,10 +37,21 @@ directory:
     docker run -d -v "$HOME"/cyberdata:/cyberdata fullnode-btcd
 
 To make image visible at https://bitnodes.21.co/ make sure
-port 8333 is accessible from outside. To make it accessible
-from host machine, publish it:
+port 8333 is accessible from host machine by publishing it
+for all hosts in the same network, and then make the port
+available from outside. Publishing:
 
     docker run -d -v -p 8333:8333 "$HOME"/cyberdata:/cyberdata fullnode-btcd
+
+You can pass all configuration parameters on `docker run`.
+For example, checking `btcd` version:
+
+    docker run --rm fullnode-btcd --version
+
+Checking `btcd` version from hash (we record it in label):
+
+    docker inspect -f "{{.Config.Labels.version}}" fullnode-btcd
+
 
 [glide.lock]: https://github.com/btcsuite/btcd/blob/master/glide.lock
 [glide.yaml]: https://github.com/btcsuite/btcd/blob/master/glide.yaml

--- a/images/run-fullnode-btcd.sh
+++ b/images/run-fullnode-btcd.sh
@@ -23,7 +23,8 @@ VERSION=`docker inspect --format='{{.Config.Labels.version}}' $IMAGE`
 PORTS="-p 8333:8333 -p 127.0.0.1:8334:8334"
 
 echo ... starting $NAME $VERSION from $IMAGE
-docker run -d --restart always $RUNUSER $PORTS --name $NAME -v /home/cyber/cyberdata/$NAME:/cyberdata $IMAGE
+docker run -d --restart always $RUNUSER $PORTS --name $NAME -v /home/cyber/cyberdata/$NAME:/cyberdata $IMAGE $*
 #    -d                  - run as daemon 
 #    --name btcd         - just convenient name to find running container
 #    -v .a.:.b.          - mount .a. in host as .b. in container
+

--- a/images/run-fullnode-btcd.sh
+++ b/images/run-fullnode-btcd.sh
@@ -5,7 +5,7 @@ VERSION=`docker inspect --format='{{.Config.Labels.version}}' $IMAGE`
 # -p 8333:8333  - host:container - expose port 8333 as 8333 from host
 #   8333 (Bitcoin P2P) is accessible from outside
 #   8334 (JSON-RPC/WS) only locally
-PORTS="-p 8333:8333 -p localhost:8334:8334"
+PORTS="-p 8333:8333 -p 127.0.0.1:8334:8334"
 
 echo ... starting $NAME $VERSION from $IMAGE
 docker run -d --restart always -u $(id -u cyber) $PORTS --name $NAME -v /home/cyber/cyberdata/$NAME:/cyberdata $IMAGE

--- a/images/run-fullnode-btcd.sh
+++ b/images/run-fullnode-btcd.sh
@@ -3,9 +3,9 @@
 set -e
 
 # empty if `cyber` does not exist, set to `cyber` uid otherwise
-CYBER=$(id -u cyber 2>/dev/null)
-if [-z "$CYBER"]; then
-  echo "Warning: no `cyber` user, running with docker default (`root`)"
+CYBER=$(id -u cyber 2>/dev/null) || true   # "|| true" ignores error
+if [ -z "$CYBER"]; then
+  echo "Warning: no 'cyber' user, running with docker default ('root')"
   RUNUSER=
 else
   # -u $(id -u cyber)  - run container under user `cyber`, param needs uid
@@ -27,4 +27,3 @@ docker run -d --restart always $RUNUSER $PORTS --name $NAME -v /home/cyber/cyber
 #    -d                  - run as daemon 
 #    --name btcd         - just convenient name to find running container
 #    -v .a.:.b.          - mount .a. in host as .b. in container
-

--- a/images/run-fullnode-btcd.sh
+++ b/images/run-fullnode-btcd.sh
@@ -1,3 +1,18 @@
+
+# fail on error
+set -e
+
+# empty if `cyber` does not exist, set to `cyber` uid otherwise
+CYBER=$(id -u cyber 2>/dev/null)
+if [-z "$CYBER"]; then
+  echo "Warning: no `cyber` user, running with docker default (`root`)"
+  RUNUSER=
+else
+  # -u $(id -u cyber)  - run container under user `cyber`, param needs uid
+  RUNUSER=-u $CYBER
+fi
+
+
 IMAGE=fullnode-btcd
 NAME=btcd
 VERSION=`docker inspect --format='{{.Config.Labels.version}}' $IMAGE`
@@ -8,8 +23,7 @@ VERSION=`docker inspect --format='{{.Config.Labels.version}}' $IMAGE`
 PORTS="-p 8333:8333 -p 127.0.0.1:8334:8334"
 
 echo ... starting $NAME $VERSION from $IMAGE
-docker run -d --restart always -u $(id -u cyber) $PORTS --name $NAME -v /home/cyber/cyberdata/$NAME:/cyberdata $IMAGE
+docker run -d --restart always $RUNUSER $PORTS --name $NAME -v /home/cyber/cyberdata/$NAME:/cyberdata $IMAGE
 #    -d                  - run as daemon 
-#    -u $(id -u cyber)   - run container under user `cyber`, param needs uid
 #    --name btcd         - just convenient name to find running container
 #    -v .a.:.b.          - mount .a. in host as .b. in container

--- a/images/run-fullnode-btcd.sh
+++ b/images/run-fullnode-btcd.sh
@@ -39,8 +39,11 @@ VERSION=`docker inspect --format='{{.Config.Labels.version}}' $IMAGE`
 PORTS="-p 8333:8333 -p 127.0.0.1:8334:8334"
 
 echo ... starting $NAME $VERSION from $IMAGE
-docker run -d --restart always $RUNUSER $PORTS --name $NAME -v $CYBERDATA:/cyberdata $IMAGE $*
-#    -d                  - run as daemon 
+ARGS=
+#ARGS=-d debug --rpcuser=cyber --rpcpass=cyber --rpclisten=0.0.0.0:8334 $*
+docker run -d --restart always --name $NAME $RUNUSER $PORTS -v $CYBERDATA:/cyberdata $IMAGE $ARGS $*
+#    -d                  - run as daemon
+#    --restart always    - when to restart container
 #    --name btcd         - just convenient name to find running container
 #    -v .a.:.b.          - mount .a. in host as .b. in container
 

--- a/images/run-fullnode-btcd.sh
+++ b/images/run-fullnode-btcd.sh
@@ -9,17 +9,17 @@ NAME=btcd
 
 # empty if `cyber` does not exist, set to `cyber` uid otherwise
 CYBER=$(id -u cyber 2>/dev/null) || true   # "|| true" ignores error
-if [ -z "$CYBER"]; then
+if [ -z "$CYBER" ]; then
   echo "Warning: no 'cyber' user, running with docker default ('root')"
   RUNUSER=
 else
   # -u $(id -u cyber)  - run container under user `cyber`, param needs uid
-  RUNUSER=-u $CYBER
+  RUNUSER="-u $CYBER"
 fi
 
 # if /cyberdata does not exist
-if [ -z "$CYBERDATA"]; then
-  if [ -z "$CYBER"]; then
+if [ -z "$CYBERDATA" ]; then
+  if [ -z "$CYBER" ]; then
     echo "Error: set CYBERDATA to store `btcd` blockchain (150Gb+)."
     echo "       Make sure to use separate partition from your root"
     echo "       to avoid filling system disk and locking your system."

--- a/images/run-fullnode-btcd.sh
+++ b/images/run-fullnode-btcd.sh
@@ -2,6 +2,11 @@
 # fail on error
 set -e
 
+
+# name of running container
+NAME=btcd
+
+
 # empty if `cyber` does not exist, set to `cyber` uid otherwise
 CYBER=$(id -u cyber 2>/dev/null) || true   # "|| true" ignores error
 if [ -z "$CYBER"]; then
@@ -12,9 +17,20 @@ else
   RUNUSER=-u $CYBER
 fi
 
+# if /cyberdata does not exist
+if [ -z "$CYBERDATA"]; then
+  if [ -z "$CYBER"]; then
+    echo "Error: set CYBERDATA to store `btcd` blockchain (150Gb+)."
+    echo "       Make sure to use separate partition from your root"
+    echo "       to avoid filling system disk and locking your system."
+    exit 1
+  else
+    CYBERDATA=/home/cyber/cyberdata/$NAME
+  fi
+fi
+
 
 IMAGE=fullnode-btcd
-NAME=btcd
 VERSION=`docker inspect --format='{{.Config.Labels.version}}' $IMAGE`
 
 # -p 8333:8333  - host:container - expose port 8333 as 8333 from host
@@ -23,7 +39,8 @@ VERSION=`docker inspect --format='{{.Config.Labels.version}}' $IMAGE`
 PORTS="-p 8333:8333 -p 127.0.0.1:8334:8334"
 
 echo ... starting $NAME $VERSION from $IMAGE
-docker run -d --restart always $RUNUSER $PORTS --name $NAME -v /home/cyber/cyberdata/$NAME:/cyberdata $IMAGE $*
+docker run -d --restart always $RUNUSER $PORTS --name $NAME -v $CYBERDATA:/cyberdata $IMAGE $*
 #    -d                  - run as daemon 
 #    --name btcd         - just convenient name to find running container
 #    -v .a.:.b.          - mount .a. in host as .b. in container
+

--- a/images/run-fullnode-btcd.sh
+++ b/images/run-fullnode-btcd.sh
@@ -39,8 +39,8 @@ VERSION=`docker inspect --format='{{.Config.Labels.version}}' $IMAGE`
 PORTS="-p 8333:8333 -p 127.0.0.1:8334:8334"
 
 echo ... starting $NAME $VERSION from $IMAGE
-ARGS=
-#ARGS=-d debug --rpcuser=cyber --rpcpass=cyber --rpclisten=0.0.0.0:8334 $*
+#ARGS=-d debug
+ARGS="--rpcuser=cyber --rpcpass=cyber --rpclisten=0.0.0.0:8334 --notls"
 docker run -d --restart always --name $NAME $RUNUSER $PORTS -v $CYBERDATA:/cyberdata $IMAGE $ARGS $*
 #    -d                  - run as daemon
 #    --restart always    - when to restart container

--- a/images/run-fullnode-btcd.sh
+++ b/images/run-fullnode-btcd.sh
@@ -2,10 +2,14 @@ IMAGE=fullnode-btcd
 NAME=btcd
 VERSION=`docker inspect --format='{{.Config.Labels.version}}' $IMAGE`
 
+# -p 8333:8333  - host:container - expose port 8333 as 8333 from host
+#   8333 (Bitcoin P2P) is accessible from outside
+#   8334 (JSON-RPC/WS) only locally
+PORTS="-p 8333:8333 -p localhost:8334:8334"
+
 echo ... starting $NAME $VERSION from $IMAGE
-docker run -d --restart always -u $(id -u cyber) -p 8333:8333 --name $NAME -v /home/cyber/cyberdata/$NAME:/cyberdata $IMAGE
+docker run -d --restart always -u $(id -u cyber) $PORTS --name $NAME -v /home/cyber/cyberdata/$NAME:/cyberdata $IMAGE
 #    -d                  - run as daemon 
 #    -u $(id -u cyber)   - run container under user `cyber`, param needs uid
-#    -p 8333:8333        - host:container - expose port 8333 as 8333 from host
 #    --name btcd         - just convenient name to find running container
 #    -v .a.:.b.          - mount .a. in host as .b. in container


### PR DESCRIPTION
* `--no-cache` to rebuild image from scratch
* expose JSON-RPC port as 127.0.0.1:8334 on host
  * [x] running under `cyber` is impossible, because `btcd` still tries to generate `.btcd/rpc.cert` and `.btcd/rpc.key` in r/o filesystem
    * set HOME in container to make `btcd` happy creating its files in `/cyberdata`
  * patched `btcd` to accept `--notls` when listening on 0.0.0.0:8334, which is still isolated inside of container
* `btcd` is run as ENTRYPOINT, allowing to pass params in `docker run`
* attempt to disable log writing with undocumented `--logdir` option (https://github.com/btcsuite/btcd/issues/969), because `docker logs` already collects data
  * [x] `--logdir=/cyberdata` writes log into `/cyberdata/mainnet/btcd.log`, which is rotated at 10Mb and then `gzip`ped
  * [x] check that empty `--logdir` disables log writing
    * `--logdir=` gives `failed to create log directory: mkdir mainnet/: permission denied`
    * `--logdir` fails with `expected argument for flag `--logdir'`
* `images/README.md` add user commands without `cyber` user