### PR TITLE
Rename fullnode-btcd to bitcoin-btcd

### DIFF
--- a/images/build-fullnode-btcd.sh
+++ b/images/build-fullnode-btcd.sh
@@ -5,7 +5,8 @@ set -e
 # set exit code to non-0 if any piped command returns error
 set -o pipefail
 
-IMAGE=fullnode-btcd
+IMAGE=bitcoin-btcd
+BUILDIMAGE=build-$IMAGE
 
 # absolute path to script's directory
 DIR=$(dirname $(readlink -f "$0"))
@@ -18,8 +19,8 @@ BINDIR=$BUILDDIR/bin
 echo "Build Dir:   $BUILDDIR"
 
 cd $BUILDDIR
-docker build --no-cache -t ${IMAGE}-build -f Dockerfile-build . | tee buildimage.log
-docker run --rm -v $BINDIR:/build ${IMAGE}-build | tee buildimage-run.log
+docker build --no-cache -t ${BUILDIMAGE} -f Dockerfile-build . | tee buildimage.log
+docker run --rm -v $BINDIR:/build ${BUILDIMAGE} | tee buildimage-run.log
 echo ... built btcd binaries:
 ls -la $BINDIR
 echo ... creating ${IMAGE} image

--- a/images/fullnode/btcd/01build.sh
+++ b/images/fullnode/btcd/01build.sh
@@ -27,7 +27,7 @@ cd $GOPATH/src/github.com/btcsuite/btcd
 git checkout $BTCDHASH
 # record revision
 REVISION=`git rev-parse --short=8 HEAD`
-echo "v`date +%Y-%m-%d`-$REVISION" >> $GOPATH/bin/TAG
+echo "v`date +%Y%m%d`-$REVISION" >> $GOPATH/bin/TAG
 echo "btcd-revision: $REVISION" >> $GOPATH/bin/VERSION
 
 echo --- applying patches ---

--- a/images/fullnode/btcd/01build.sh
+++ b/images/fullnode/btcd/01build.sh
@@ -26,15 +26,16 @@ fi
 cd $GOPATH/src/github.com/btcsuite/btcd
 git checkout $BTCDHASH
 # record revision
-touch $GOPATH/bin/VERSION
-echo "btcd-revision: `git rev-parse HEAD`" >> $GOPATH/bin/VERSION
+REVISION=`git rev-parse --short=8 HEAD`
+echo "v`date +%Y-%m-%d`-$REVISION" >> $GOPATH/bin/TAG
+echo "btcd-revision: $REVISION" >> $GOPATH/bin/VERSION
 
 echo --- applying patches ---
 git -c user.name='cyber' -c user.email='cyber@build' am $DIR/02notls.patch
-echo "patch-revision: `git rev-parse HEAD`" >> $GOPATH/bin/VERSION
+echo "patch-revision: `git rev-parse --short=8 HEAD`" >> $GOPATH/bin/VERSION
 
 git -c user.name='cyber' -c user.email='cyber@build' am $DIR/03getblockbynumber.patch
-echo "patch-revision: `git rev-parse HEAD`" >> $GOPATH/bin/VERSION
+echo "patch-revision: `git rev-parse --short=8 HEAD`" >> $GOPATH/bin/VERSION
 
 echo --- fetch dependencies into vendor/ ---
 $GOPATH/bin/glide install

--- a/images/fullnode/btcd/README.md
+++ b/images/fullnode/btcd/README.md
@@ -1,3 +1,18 @@
+### tl;dr
+
+From `images/` subdir in repository run:
+
+    CYBERDATA=/datadir ./run-fullnode-btcd.sh
+
+ * executes `cybernode/bitcoin-btcd`
+ * JSON-RPC at http://cyber:cyber@127.0.0.1:8334
+ * blockchain data stored in `/datadir`
+
+Building `cybernode/bitcoin-btcd`:
+
+    ./build-fullnode-btcd.sh
+
+
 ### btcd setup
 
 `btcd` lacks single BTCDHOME setting to root its data


### PR DESCRIPTION
This changes packaging convention to `chainname-softname`, because by default we assume that we want fullnode for blockchains.

Also build images are now prefixed with `build-` rather than suffixed with `-build`. This makes it easier to spot them and cleanup.

Also saves TAG and VERSION info into `/cyberapp/bin ` for debug/diag.